### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,8 @@ defaults:
 jobs:
   create_nuget:
     name: Pack Template NuGet Package
+    permissions:
+      contents: read
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/MarcelMichau/dotnet-starter-project-template/security/code-scanning/2](https://github.com/MarcelMichau/dotnet-starter-project-template/security/code-scanning/2)

To fix the problem, add the `permissions` block to the `create_nuget` job, specifying the minimum permissions it needs for its steps. The checkout action requires `contents: read` to clone the repository; other steps (setup-dotnet, packing, upload-artifact) do not require write permissions. You should edit the `.github/workflows/package.yml` file to add:

```yaml
permissions:
  contents: read
```

to the `create_nuget` job definition (below `name: Pack Template NuGet Package`, above `runs-on:`). No installation of new dependencies is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
