### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,6 @@
 name: Build + Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MarcelMichau/dotnet-starter-project-template/security/code-scanning/1](https://github.com/MarcelMichau/dotnet-starter-project-template/security/code-scanning/1)

To fix this problem, explicitly set the permissions at the workflow root by adding a top-level `permissions` block. This ensures the GITHUB_TOKEN for all jobs in the workflow has only the specified minimal permission for accessing code contents in read mode. Since none of the steps require write access or additional scopes, this is both secure and functional. The change should be made by inserting the following lines directly under the workflow `name:` line and before the `on:` trigger. No changes to the jobs or workflow logic are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
